### PR TITLE
Add abstraction for creating components

### DIFF
--- a/examples/simple/index.ts
+++ b/examples/simple/index.ts
@@ -43,10 +43,10 @@ const main = component<Model, ViewOut>({
     return Do(function*(): Iterator<Component<any>> {
       yield span("Please enter an email address: ");
       const {inputValue: emailB} = yield input();
-      yield br();
+      yield br;
       yield text("The address is ");
       yield text(validB.map(t => t ? "valid" : "invalid"));
-      yield br();
+      yield br;
       const {click: calcLength} = yield button("Calculate length");
       yield text(" The length of the email is ");
       yield text(lengthB);


### PR DESCRIPTION
This PR adds `CreateDomNow` which is a first stab at a reusable way of creating components matching the normal DOM elements.

`CreateDomNow` also ensures that DOM nodes and event listeners are only created inside a now computation (in the `run` method). The old implementation didn't do that. The `br` function for instance just created and returned a DOM element directly. Since DOM elements are a mutable data structure this lead to impurity. For instance, in the old implementation this

```js
yield br();
yield br();
```

wasn't the same as:

```js
const myBr = br();
yield myBr;
yield myBr;
```

Because only one actual `br` element would be created in the later case.